### PR TITLE
Add GitHub action for pushing docker image, fixes #3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker:
+    name: Build and publish images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker metadata for mailadmin
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: aspettl/mailadmin
+          flavor: |
+            latest=false
+          tags: |
+            type=edge
+            type=ref,event=tag
+            type=ref,event=pr
+      - name: Docker metadata for configreload
+        id: meta_configreload
+        uses: docker/metadata-action@v3
+        with:
+          images: aspettl/docker-mailserver-configreload
+          flavor: |
+            latest=false
+          tags: |
+            type=edge
+            type=ref,event=tag
+            type=ref,event=pr
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push mailadmin
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push docker-mailserver-configreload
+        uses: docker/build-push-action@v2
+        with:
+          context: integrations/docker-mailserver-configreload
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta_configreload.outputs.tags }}
+          labels: ${{ steps.meta_configreload.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ a public repository.
 * [Manage Domains](./screenshots/manage_domains.png)
 * [Manage Accounts](./screenshots/manage_accounts.png)
 
+## Docker images
+
+Prebuilt images for the latest commit of the `main` branch are available via
+DockerHub:
+
+* `aspettl/mailadmin:edge`
+* `aspettl/docker-mailserver-configreload:edge`
+
+New tags for versions will be pushed with the version number as docker image tag.
+
 ## Start/try out locally
 
 Requirements:
@@ -51,7 +61,7 @@ password "test".
 
 ## Build docker images
 
-Increase version number in `docker-compose.yml` and use `docker-compose build`.
+You can use `docker-compose build` to build all docker images.
 
 ## Local docker-based staging environment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   mailadmin:
     build: .
-    image: registry.k8s.spettl.net/mailadmin:0.0.16
+    image: mailadmin
     environment:
       - DATABASE_URL=mysql2://mailadmin:@localhost/mailadmin_development
       - MAILSERVER_HOSTNAME=mail.example.com
@@ -25,7 +25,7 @@ services:
   # Integration to docker-mailserver, config is written to volume "docker-mailserver-config"
   configreload:
     build: integrations/docker-mailserver-configreload
-    image: registry.k8s.spettl.net/docker-mailserver-configreload:0.0.16
+    image: docker-mailserver-configreload
     depends_on:
       - init-logs
       - mailadmin


### PR DESCRIPTION
* build both the mailadmin and configreload images
* push to DockerHub (only main branch and tags)
* build only without push for PRs

This fixes https://github.com/aspettl/mailadmin/issues/3.