### PR TITLE
Fix jinja2 rendering problem in configreload

### DIFF
--- a/integrations/docker-mailserver-configreload/Dockerfile
+++ b/integrations/docker-mailserver-configreload/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="aaron@spettl.de"
 
 RUN apk --no-cache add bash coreutils curl
 
-RUN pip install j2cli
+RUN pip install jinjanator
 
 COPY bin/ /usr/local/bin/
 COPY templates/ /usr/local/share/templates/

--- a/integrations/docker-mailserver-configreload/Dockerfile
+++ b/integrations/docker-mailserver-configreload/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.12-alpine
 LABEL maintainer="aaron@spettl.de"
 
 RUN apk --no-cache add bash coreutils curl

--- a/integrations/docker-mailserver-configreload/bin/build_config.sh
+++ b/integrations/docker-mailserver-configreload/bin/build_config.sh
@@ -15,5 +15,5 @@ fi
 
 JSON=$(curl --silent --fail --header "Authorization: Bearer $MAILADMIN_API_TOKEN" --write-out "%{stderr}[$(date)] Getting JSON data, HTTP status code: %{http_code}\n%{stdout}\n" $MAILADMIN_URL/api/v1/export.json)
 
-echo "$JSON" | jinjanate --format=json /usr/local/share/templates/postfix-accounts.cf > $CONFIG_TMP/postfix-accounts.cf
-echo "$JSON" | jinjanate --format=json /usr/local/share/templates/postfix-virtual.cf > $CONFIG_TMP/postfix-virtual.cf
+echo "$JSON" | jinjanate --quiet --format=json /usr/local/share/templates/postfix-accounts.cf > $CONFIG_TMP/postfix-accounts.cf
+echo "$JSON" | jinjanate --quiet --format=json /usr/local/share/templates/postfix-virtual.cf > $CONFIG_TMP/postfix-virtual.cf

--- a/integrations/docker-mailserver-configreload/bin/build_config.sh
+++ b/integrations/docker-mailserver-configreload/bin/build_config.sh
@@ -7,13 +7,13 @@ then
   exit 1
 fi
 
-if ! which j2 >/dev/null
+if ! which jinjanate >/dev/null
 then
-  echo "Make sure you installed j2: pip install j2cli"
+  echo "Make sure you installed jinjanate: pip install jinjanator"
   exit 1
 fi
 
 JSON=$(curl --silent --fail --header "Authorization: Bearer $MAILADMIN_API_TOKEN" --write-out "%{stderr}[$(date)] Getting JSON data, HTTP status code: %{http_code}\n%{stdout}\n" $MAILADMIN_URL/api/v1/export.json)
 
-echo "$JSON" | j2 --format=json /usr/local/share/templates/postfix-accounts.cf > $CONFIG_TMP/postfix-accounts.cf
-echo "$JSON" | j2 --format=json /usr/local/share/templates/postfix-virtual.cf > $CONFIG_TMP/postfix-virtual.cf
+echo "$JSON" | jinjanate --format=json /usr/local/share/templates/postfix-accounts.cf > $CONFIG_TMP/postfix-accounts.cf
+echo "$JSON" | jinjanate --format=json /usr/local/share/templates/postfix-virtual.cf > $CONFIG_TMP/postfix-virtual.cf


### PR DESCRIPTION
**Problem**:
```
Traceback (most recent call last):
  File "/usr/local/bin/j2", line 5, in <module>
    from j2cli import main
  File "/usr/local/lib/python3.12/site-packages/j2cli/__init__.py", line 10, in <module>
    from j2cli.cli import main
  File "/usr/local/lib/python3.12/site-packages/j2cli/cli.py", line 8, in <module>
    import imp, inspect
ModuleNotFoundError: No module named 'imp'
```
on recent builds because the configreload docker base image was upgraded to python 3.12. See issue https://github.com/kolypto/j2cli/issues/80

**Solution**:
Switch to https://github.com/kpfleming/jinjanator instead.