### PR TITLE
Pin Ruby docker image to Alpine Linux 3.18 for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-alpine AS builder
+FROM ruby:3.2.2-alpine3.18 AS builder
 
 RUN apk --no-cache add build-base zlib-dev tzdata openssl-dev mariadb-dev shared-mime-info
 
@@ -18,7 +18,7 @@ COPY . .
 RUN RAILS_ENV=production SECRET_KEY_BASE=irrelevant bundle exec rails assets:precompile
 
 
-FROM ruby:3.2.2-alpine
+FROM ruby:3.2.2-alpine3.18
 LABEL maintainer="aaron@spettl.de"
 
 RUN apk --no-cache add zlib tzdata libssl1.1 mariadb-connector-c shared-mime-info


### PR DESCRIPTION
Alpine Linux 3.19 requires at least different packages. Pin version to 3.18 for now to fix the broken build.