### PR TITLE
Disable warning about image processing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,9 @@ module Mailadmin
       SecureRandom.hex(64)
     end
 
+    # We do not need image processing in Active Storage
+    config.active_storage.variant_processor = :disabled
+
     # Custom application configuration
     config.mailserver_hostname  = ENV.fetch('MAILSERVER_HOSTNAME') { Socket.gethostname }
     default_mx_record           = "@   3600    IN  MX  10  #{config.mailserver_hostname}."


### PR DESCRIPTION
At container startup:
```
Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`.
```